### PR TITLE
Use secure URI in Vcs control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xdms (1.3.2-7) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Fri, 14 Sep 2018 18:13:00 +0100
+
 xdms (1.3.2-6) unstable; urgency=low
 
   * [ff9593da] Fix indentation in debian/copyright file.

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
 Build-Depends: debhelper (>= 9), autotools-dev, dpkg-dev (>= 1.16.1~)
 Standards-Version: 3.9.4
 Homepage: http://zakalwe.fi/~shd/foss/xdms/
-Vcs-Git: git://github.com/glaubitz/xdms-debian.git
+Vcs-Git: https://github.com/glaubitz/xdms-debian.git
 Vcs-Browser: https://github.com/glaubitz/xdms-debian
 
 Package: xdms


### PR DESCRIPTION
Use secure URI in Vcs control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
