### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
 Build-Depends: debhelper-compat (= 12), autotools-dev, dpkg-dev (>= 1.16.1~)
 Standards-Version: 3.9.4
 Homepage: https://zakalwe.fi/~shd/foss/xdms/
-Vcs-Git: git://github.com/glaubitz/xdms-debian.git
+Vcs-Git: https://github.com/glaubitz/xdms-debian.git
 Vcs-Browser: https://github.com/glaubitz/xdms-debian
 
 Package: xdms

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
 Build-Depends: debhelper-compat (= 12), autotools-dev, dpkg-dev (>= 1.16.1~)
 Standards-Version: 3.9.4
-Homepage: http://zakalwe.fi/~shd/foss/xdms/
+Homepage: https://zakalwe.fi/~shd/foss/xdms/
 Vcs-Git: git://github.com/glaubitz/xdms-debian.git
 Vcs-Browser: https://github.com/glaubitz/xdms-debian
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,14 +5,14 @@ Source: http://zakalwe.fi/~shd/foss/xdms/
 Files: *
 Copyright: Andre Rodrigues de la Rocha <adlroc@usa.net>
            Heikki Orsila <heikki.orsila@iki.fi>
-License: Public Domain
+License: Public-Domain
 
 Files: debian/*
 Copyright: 2005-2007 Gürkan Sengün <gurkan@linuks.mine.nu>
            2013 John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
-License: Public Domain
+License: Public-Domain
 
-License: Public Domain
+License: Public-Domain
  xDMS is released as public domain software.  You can spread it, modify it
  and  use  it in any way you like.  You can do anything with it without even
  asking  me  first.   But I would like to know if you do something cool with

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,12 +4,12 @@ Source: http://zakalwe.fi/~shd/foss/xdms/
 
 Files: *
 Copyright: Andre Rodrigues de la Rocha <adlroc@usa.net>
-	   Heikki Orsila <heikki.orsila@iki.fi>
+           Heikki Orsila <heikki.orsila@iki.fi>
 License: Public Domain
 
 Files: debian/*
 Copyright: 2005-2007 Gürkan Sengün <gurkan@linuks.mine.nu>
-	   2013 John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
+           2013 John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
 License: Public Domain
 
 License: Public Domain

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: xDMS
 Source: http://zakalwe.fi/~shd/foss/xdms/
 

--- a/debian/rules
+++ b/debian/rules
@@ -55,4 +55,4 @@ binary-arch: build install
 	dh_builddeb
 
 binary: binary-indep binary-arch
-.PHONY: build clean binary-indep binary-arch binary install 
+.PHONY: build clean binary-indep binary-arch binary install


### PR DESCRIPTION
Fix some issues reported by lintian

* Trim trailing whitespace. ([trailing-whitespace](https://lintian.debian.org/tags/trailing-whitespace))
* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri))
* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text))
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))
* Replace spaces in short license names with dashes. ([space-in-std-shortname-in-dep5-copyright](https://lintian.debian.org/tags/space-in-std-shortname-in-dep5-copyright))
* Use secure URI in Vcs control header Vcs-Git. ([vcs-field-uses-insecure-uri](https://lintian.debian.org/tags/vcs-field-uses-insecure-uri))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/35/6d15be1d38070295d30c383139940084c649b6.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/c0/7b750b58700fdefcd2df57523aba491c4adc0a.debug
### Control files of package xdms: lines which differ (wdiff format)
* Homepage: [-http&#8203;://zakalwe.fi/~shd/foss/xdms/-] {+https&#8203;://zakalwe.fi/~shd/foss/xdms/+}
### Control files of package xdms-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-c07b750b58700fdefcd2df57523aba491c4adc0a-] {+356d15be1d38070295d30c383139940084c649b6+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/459f38b1-29b6-4326-bd39-6859178648a9/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/459f38b1-29b6-4326-bd39-6859178648a9/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/xdms/459f38b1-29b6-4326-bd39-6859178648a9.